### PR TITLE
Handle empty debug data in ShippingManager

### DIFF
--- a/app.js
+++ b/app.js
@@ -802,8 +802,8 @@ class ShippingManager {
         const responseEl = this.getElement('debug-response');
         const stateEl = this.getElement('debug-state');
         
-        requestEl.textContent = JSON.stringify(this.state.lastRequest, null, 2) || 'No requests made yet';
-        responseEl.textContent = JSON.stringify(this.state.lastResponse, null, 2) || 'No responses received yet';
+        requestEl.textContent = this.state.lastRequest ? JSON.stringify(this.state.lastRequest, null, 2) : 'No requests made yet';
+        responseEl.textContent = this.state.lastResponse ? JSON.stringify(this.state.lastResponse, null, 2) : 'No responses received yet';
         stateEl.textContent = JSON.stringify({
             platform: this.state.platform,
             connected: this.state.connected,
@@ -844,3 +844,7 @@ if (document.readyState === 'loading') {
 
 // Global function for removing products (called from dynamically generated HTML)
 window.app = { removeProduct: (id) => app?.removeProduct(id) };
+
+if (typeof module !== 'undefined') {
+    module.exports = ShippingManager;
+}

--- a/app.test.js
+++ b/app.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const elements = {
+  'debug-modal': { classList: { remove: () => {}, add: () => {} } },
+  'debug-request': { textContent: '' },
+  'debug-response': { textContent: '' },
+  'debug-state': { textContent: '' }
+};
+
+global.document = {
+  readyState: 'loading',
+  addEventListener: () => {},
+  getElementById: (id) => {
+    if (!elements[id]) {
+      throw new Error(`Element with id '${id}' not found`);
+    }
+    return elements[id];
+  }
+};
+
+global.window = {};
+
+const ShippingManager = require('./app.js');
+
+test('showDebugModal provides fallback text when no request/response', () => {
+  const manager = new ShippingManager();
+  manager.showDebugModal();
+  assert.strictEqual(elements['debug-request'].textContent, 'No requests made yet');
+  assert.strictEqual(elements['debug-response'].textContent, 'No responses received yet');
+});


### PR DESCRIPTION
## Summary
- ensure the debug modal shows clear fallback text when no request or response exists
- expose `ShippingManager` for Node-based tests
- add a unit test covering the debug modal fallback behaviour

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_688dce30da3c832f979df08644ee7668